### PR TITLE
Update license to CC-BY-SA 4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 This project is based on the orignal work of David and Franck Dernoncourt for wiki 4 games, it displays a rating bar on a wiki page that the user can use to rate something from 1 - 100.
 
-for useage see: http://www.wiki4games.com/Wiki4Games:W4G_Rating_Bar/syntax
+For usage see: http://www.wiki4games.com/Wiki4Games:W4G_Rating_Bar/syntax
 
-for installation see: https://www.mediawiki.org/wiki/Extension:W4G_Rating_Bar
+For installation see: https://www.mediawiki.org/wiki/Extension:W4G_Rating_Bar
 
 I've only tested the rating bar functionality on MW 1.27.1 probably works with 1.27, 1.26 and earlier may not work.
-Tthe mmigration feature to update from rating bar v1.1 I have not tested at all, I updated so it no longer generates errors but nothing else, use at your own risk.
+The mmigration feature to update from rating bar v1.1 I have not tested at all, I updated so it no longer generates errors but nothing else, use at your own risk.
+
+This is licensed under a [Creative Commons Attribution-ShareAlike License, version 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+We are aware that this is a terrible license for code, but we didn't choose it.

--- a/SpecialW4GRBMigrate.php
+++ b/SpecialW4GRBMigrate.php
@@ -8,11 +8,10 @@
 **                - Franck Dernoncourt <www.francky.me>
 **
 ** Home Page: http://www.wiki4games.com/Wiki4Games:W4G Rating Bar
-** Version: 2.1.0
 **
 ** This program is licensed under the Creative Commons
-** Attribution-Noncommercial-No Derivative Works 3.0 Unported license
-** <http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode>
+** Attribution-ShareAlike 4.0 license
+** <https://creativecommons.org/licenses/by-sa/4.0/>
 **
 ** This program is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/SpecialW4GRB_body.php
+++ b/SpecialW4GRB_body.php
@@ -7,12 +7,11 @@
 **                - David Dernoncourt <www.patheticcockroach.com>
 **                - Franck Dernoncourt <www.francky.me>
 **
-** Home Page : http://www.wiki4games.com/Wiki4Games:W4G Rating Bar
-** Version: 2.1.1
+** Home Page: http://www.wiki4games.com/Wiki4Games:W4G Rating Bar
 **
 ** This program is licensed under the Creative Commons
-** Attribution-Noncommercial-No Derivative Works 3.0 Unported license
-** <http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode>
+** Attribution-ShareAlike 4.0 license
+** <https://creativecommons.org/licenses/by-sa/4.0/>
 **
 ** This program is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/credits.txt
+++ b/credits.txt
@@ -4,11 +4,10 @@ Copyright (C)2011
                - Franck Dernoncourt <www.francky.me>
 
 Home Page: http://www.wiki4games.com/Wiki4Games:W4G Rating Bar
-Version: 2.1.2
 
 This program is licensed under the Creative Commons
-Attribution-Noncommercial-No Derivative Works 3.0 Unported license
-<http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode>
+Attribution-ShareAlike 4.0 license
+<https://creativecommons.org/licenses/by-sa/4.0/>
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/w4g_rb-page.class.php
+++ b/w4g_rb-page.class.php
@@ -10,8 +10,8 @@
 ** Home Page : http://www.wiki4games.com/Wiki4Games:W4G Rating Bar
 **
 ** This program is licensed under the Creative Commons
-** Attribution-Noncommercial-No Derivative Works 3.0 Unported license
-** <http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode>
+** Attribution-ShareAlike 4.0 license
+** <https://creativecommons.org/licenses/by-sa/4.0/>
 **
 ** The attribution part of the license prohibits any unauthorized editing of any line related to
 ** $wgExtensionCredits['parserhook'][] and $wgExtensionCredits['specialpage'][]

--- a/w4g_rb.css
+++ b/w4g_rb.css
@@ -8,8 +8,8 @@
 ** Home Page : http://www.wiki4games.com/Wiki4Games:W4G Rating Bar
 **
 ** This program is licensed under the Creative Commons
-** Attribution-Noncommercial-No Derivative Works 3.0 Unported license
-** <http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode>
+** Attribution-ShareAlike 4.0 license
+** <https://creativecommons.org/licenses/by-sa/4.0/>
 **
 ** This program is distributed in the hope that it will be useful,
 ** but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/w4g_rb.php
+++ b/w4g_rb.php
@@ -8,11 +8,10 @@
 **                - Franck Dernoncourt <www.francky.me>
 **
 ** Home Page : http://www.wiki4games.com/Wiki4Games:W4G Rating Bar
-** Version: 2.1.2
 **
 ** This program is licensed under the Creative Commons
-** Attribution-Noncommercial-No Derivative Works 3.0 Unported license
-** <http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode>
+** Attribution-ShareAlike 4.0 license
+** <https://creativecommons.org/licenses/by-sa/4.0/>
 **
 ** The attribution part of the license prohibits any unauthorized editing of any line related to
 ** $wgExtensionCredits['parserhook'][] and $wgExtensionCredits['specialpage'][]


### PR DESCRIPTION
These files are all licensed under a NoDerivs, which would technically makes this fork illegal.  But hey, they authors changed licenses on the wiki page, so let's go ahead and update the license here.

https://www.mediawiki.org/w/index.php?title=Extension:W4G_Rating_Bar&diff=prev&oldid=1967430
Shows authors' license grant of CC-BY-SA, which makes this fork legal.